### PR TITLE
Stop errors from other servers breaking the friendable list page

### DIFF
--- a/web_server/nodes/models.py
+++ b/web_server/nodes/models.py
@@ -49,7 +49,7 @@ class Node(models.Model):
         #     self.password_registered_on_foreign_server)
         super(Node, self).save(*args, **kwargs)
 
-    def get_safe_api_url(self, path):
+    def get_safe_api_url(self, path = ''):
         """
         Returns a url that will access this Node's API location.
         Abstracts away choices like if a slash should be appended, or what protocol to use


### PR DESCRIPTION
Added a try/catch block, and pipe errors to front end to display them if needed.
Closes issue #179 